### PR TITLE
Add possibility to define default options (only attach_jquery_bettertabs_inline for now) in an initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ Or if you prefer the compressed version:
 
 This works the same way as [jquery-rails](https://github.com/rails/jquery-rails); you don't need to copy-paste the javascript code in your app because it will be served using the Asset Pipeline.
 
+Add an optional initializer (e.g. `app/config/initializers/bettertabs.rb`) to change the default configuration:
+
+    Bettertabs.configure do |config|
+      # Render a Javascript snippet to initialize the tabs automatically after rendering the tabs.
+      # This requires that you include jQuery before the tabs are rendered.
+      # Default: true
+      # config.attach_jquery_bettertabs_inline = false
+    end
+
 ## Usage and examples ##
 
 Bettertabs supports three kinds of tabs:

--- a/app/helpers/bettertabs_helper.rb
+++ b/app/helpers/bettertabs_helper.rb
@@ -53,7 +53,7 @@ module BettertabsHelper
     options[:class] ||= "bettertabs"
     options[:id] ||= bettertabs_id
     options[:render_only_active_content] = controller.request.xhr? unless options.include?(:render_only_active_content)
-    attach_jquery_bettertabs_inline = options.include?(:attach_jquery_bettertabs_inline) ? options.delete(:attach_jquery_bettertabs_inline) : true
+    attach_jquery_bettertabs_inline = options.include?(:attach_jquery_bettertabs_inline) ? options.delete(:attach_jquery_bettertabs_inline) : Bettertabs.configuration.attach_jquery_bettertabs_inline
     builder = BettertabsBuilder.new(bettertabs_id, self, selected_tab_id, options)
     yield(builder)
     b = builder.render

--- a/lib/bettertabs.rb
+++ b/lib/bettertabs.rb
@@ -1,2 +1,15 @@
+require 'bettertabs/configuration'
 require 'bettertabs/engine'
 require 'bettertabs/bettertabs_builder'
+
+module Bettertabs
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
+  end
+end

--- a/lib/bettertabs/configuration.rb
+++ b/lib/bettertabs/configuration.rb
@@ -1,0 +1,9 @@
+module Bettertabs
+  class Configuration
+    attr_accessor :attach_jquery_bettertabs_inline
+
+    def initialize
+      @attach_jquery_bettertabs_inline = true
+    end
+  end
+end


### PR DESCRIPTION
I didn't want to render the JS code to activate the tabs directly after rendering them (it requires jQuery to be available at that point, which I include at the bottom of the page), so I used the attach_jquery_bettertabs_inline option but including it with every call to the helper got old very quick, so I added a simple Configuration class to be able to set attach_jquery_bettertabs_inline in an initializer.

The Configuration class could be used to store many more options (like render_only_active_content, class, id, etc.).
