### PR TITLE
Add possibility to define content that is rendered between tab list and tab content

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ This will show three tabs: 'My Profile' (static, that will be preloaded and show
 
 The option `:selected_tab` specifies the default selected tab, when the page is loaded. It only defines which tab is selected when no `{bettertabs_id}_selected_tab` param is present.
 
+The markup generated from Bettertabs consists of a tab list `<ul>` containing the tabs (one `<li>` containing a `<a>` per tab) and a `<div class="content">` for each tab holding the tab content.  
+In case you want to render additional content between the tab list and the tab contents, you can do so by using `content_for :before_tab_id`:
+
+    - content_for :before_profile_tabs do
+      %p This content is rendered between tab list and tab content!
+
+    = bettertabs :profile_tabs do |tab|
+      = tab.static :general, 'My Profile' do
+        Foo!
+
+Note that the name of the `content_for` block must be consistent with id of the tabs (`bettertabs :profile_tabs` -> `content_for :before_profile_tabs`).
+
 ### More examples and documentation: ###
 
   * [EXAMPLES document](https://github.com/agoragames/bettertabs/blob/master/doc/EXAMPLES.md)

--- a/app/helpers/bettertabs_helper.rb
+++ b/app/helpers/bettertabs_helper.rb
@@ -54,6 +54,7 @@ module BettertabsHelper
     options[:id] ||= bettertabs_id
     options[:render_only_active_content] = controller.request.xhr? unless options.include?(:render_only_active_content)
     attach_jquery_bettertabs_inline = options.include?(:attach_jquery_bettertabs_inline) ? options.delete(:attach_jquery_bettertabs_inline) : true
+    options[:after_tabs_content] = content_for(:"after_#{bettertabs_id}")
     builder = BettertabsBuilder.new(bettertabs_id, self, selected_tab_id, options)
     yield(builder)
     b = builder.render

--- a/lib/bettertabs/bettertabs_builder.rb
+++ b/lib/bettertabs/bettertabs_builder.rb
@@ -8,6 +8,7 @@ class BettertabsBuilder
     @template = template
     @selected_tab_id = selected_tab_id
     @render_only_active_content = options.delete(:render_only_active_content) # used in ajax calls
+    @after_tabs_content = options.delete(:after_tabs_content)
     @wrapper_html_options = options
     
     @tabs = []
@@ -110,6 +111,9 @@ class BettertabsBuilder
            end.join.html_safe
          end +
        
+         # After tabs content
+         @after_tabs_content +
+
          # Content sections
          @contents.map do |content|
            tag(:div, content[:html_options]) do


### PR DESCRIPTION
In my layout I need to render some content between the tab list and the content divs, so I added the possibility to define content using `content_for` before calling the `bettertabs` helper.
